### PR TITLE
chore(migrations): move 0003/0004 to _hold (pending policy fix)

### DIFF
--- a/supabase/migrations/_hold/0003_storage_buckets.sql.off
+++ b/supabase/migrations/_hold/0003_storage_buckets.sql.off
@@ -1,0 +1,23 @@
+insert into storage.buckets (id, name, public) values ('user_uploads','user_uploads', false) on conflict (id) do nothing;
+insert into storage.buckets (id, name, public) values ('zox_logs','zox_logs', false) on conflict (id) do nothing;
+insert into storage.buckets (id, name, public) values ('public_assets','public_assets', true) on conflict (id) do nothing;
+
+create policy if not exists "user read own uploads"
+on storage.objects for select to authenticated
+using (bucket_id = 'user_uploads' and owner = auth.uid());
+
+create policy if not exists "user write own uploads"
+on storage.objects for insert to authenticated
+with check (bucket_id = 'user_uploads' and owner = auth.uid());
+
+create policy if not exists "service read/write logs"
+on storage.objects for all to service_role
+using (bucket_id = 'zox_logs') with check (bucket_id = 'zox_logs');
+
+create policy if not exists "public read assets"
+on storage.objects for select to anon
+using (bucket_id = 'public_assets');
+
+create policy if not exists "service write public assets"
+on storage.objects for insert to service_role
+with check (bucket_id = 'public_assets');

--- a/supabase/migrations/_hold/0004_cost_guards.sql.off
+++ b/supabase/migrations/_hold/0004_cost_guards.sql.off
@@ -1,0 +1,4 @@
+alter database postgres set statement_timeout = '15s';
+alter database postgres set idle_in_transaction_session_timeout = '30s';
+alter database postgres set log_min_duration_statement = '500ms';
+alter database postgres set autovacuum_naptime = '30s';


### PR DESCRIPTION
Move as migrations 0003 e 0004 para a pasta `_hold/` com extensão `.off`, 
desativando sua execução no Supabase CLI.

Motivo: os arquivos usam `CREATE POLICY IF NOT EXISTS`, 
sintaxe não suportada pelo Postgres.

Impacto: `supabase db push` agora aplica apenas a migration 0005 (signals), 
mantendo histórico limpo sem quebrar deploy.
